### PR TITLE
Adds multi-arch support to petsc-docker build

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -34,9 +34,12 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       
+      - name: Set up docker
+        run: docker buildx create --name builder --use
+
       - name: Run tests
         run: |
-            docker build . --file Dockerfile --tag $IMAGE_NAME
+            docker buildx build . --file Dockerfile --tag $IMAGE_NAME --load           
             docker build . --file DockerAblateFile --tag ablate_image
 
   # Push image to GitHub Packages.

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -21,8 +21,8 @@ on:
   pull_request:
 
 env:
-  # TODO: Change variable to your image's name.
   IMAGE_NAME: petsc-build
+  PLATFORMS: linux/arm64,linux/amd64
 
 jobs:
   # Run tests.
@@ -48,8 +48,11 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
+      - name: Set up docker
+        run: docker buildx create --name builder --use
+
       - name: Build image
-        run: docker build . --file Dockerfile --tag $IMAGE_NAME            
+        run: docker buildx build . --file Dockerfile --tag $IMAGE_NAME --load           
       
       - name: Test ablate
         if: github.event_name != 'workflow_dispatch'
@@ -71,11 +74,9 @@ jobs:
           echo IMAGE_ID=$IMAGE_ID
           echo VERSION=$VERSION
 
-          docker tag $IMAGE_NAME $IMAGE_ID:latest
-          docker tag $IMAGE_NAME $IMAGE_ID:$VERSION
-          docker push --all-tags $IMAGE_ID
+          docker buildx build . --file Dockerfile --platform ${PLATFORMS} --tag $IMAGE_ID:latest --tag $IMAGE_ID:$VERSION --push
+
    
-          
       - name: set version and push tag
         id: tag_version
         uses: mathieudutour/github-tag-action@v5

--- a/Dockerfile
+++ b/Dockerfile
@@ -36,7 +36,8 @@ ENV PETSC_SETUP_ARGS --with-cc=gcc \
 	--download-superlu_dist \
 	--download-triangle \
 	--download-slepc \
-	--download-tchem \
+	--download-tchem=https://github.com/UBCHREST/tchemv1.git \
+	--download-tchem-commit=0354366 \
 	--download-opencascade \
 	--with-libpng \
 	--download-zlib


### PR DESCRIPTION
This adds multi-arch support and when combined with the new tensor-flow lib allows easy local development without installing petsc on x86_64 and arm machines. 