### PR TITLE
Klbudzin remove arm 64 support (temp)

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -44,7 +44,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        arch: [ { runson: ARM64, id: -arm64 }, { runson: ubuntu-latest, id: -amd64 } ]
+        arch: [ { runson: ubuntu-latest, id: -amd64 } ]
+        #arch: [ { runson: ARM64, id: -arm64}, { runson: ubuntu-latest, id: -amd64 } ] # disabling arm64 until we can figure out either new machines to run these on or wipe/ reset Matt's old ones -klb
         compiler: [ 
             { cc: gcc, cxx: g++, debugFlags: "-g -O0",  optFlags: "-g -O", id: -gcc },
             { cc: clang, cxx: clang++, debugFlags: "-g -O0",  optFlags: "-g -O3",  id: -clang } ]
@@ -115,7 +116,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        arch: [ { runson: ARM64, id: -arm64 }, { runson: ubuntu-latest, id: -amd64 } ]
+        arch: [ { runson: ubuntu-latest, id: -amd64 } ]
+        #arch: [ { runson: ARM64, id: -arm64}, { runson: ubuntu-latest, id: -amd64 } ] # disabling arm64 until we can figure out either new machines to run these on or wipe/ reset Matt's old ones -klb
         compiler: [ 
             { cc: gcc, cxx: g++, debugFlags: "-g -O0",  optFlags: "-g -O", id: -gcc },
             { cc: clang, cxx: clang++, debugFlags: "-g -O0",  optFlags: "-g -O3",  id: -clang } ]
@@ -166,7 +168,8 @@ jobs:
     strategy:
       max-parallel: 1
       matrix:
-        arch: [ { runson: ARM64, id: -arm64 }, { runson: ubuntu-latest, id: -amd64 } ]
+        arch: [ { runson: ubuntu-latest, id: -amd64 } ]
+        #arch: [ { runson: ARM64, id: -arm64}, { runson: ubuntu-latest, id: -amd64 } ] # disabling arm64 until we can figure out either new machines to run these on or wipe/ reset Matt's old ones -klb
         compiler: [ {id: -gcc }, { id: -clang } ]
         indices: [ { index64bit: 0, id: "" },  { index64bit: 1, id: "-index64" } ]
         include:

--- a/.github/workflows/petsc-docker-pr.yml
+++ b/.github/workflows/petsc-docker-pr.yml
@@ -33,7 +33,7 @@ jobs:
       fail-fast: false
       matrix:
         arch: [ { runson: ubuntu-latest, id: -amd64 } ]
-        #arch: [ { runson: ARM64, id: -arm64}, { runson: ubuntu-latest, id: -amd64 } ] # disabling arm64 until we can figure out either new machines to run these on or wipe/ reset Matt's old ones -klb
+        #arch: [ { runson: ARM64, id: -arm64}, { runson: ubuntu-latest, id: -amd64 } ] # disabling arm64 until we can figure out either new machines to run these on or wipe/ reset Matt's old ones -klb 
         compiler: [ 
             { cc: gcc, cxx: g++, debugFlags: "-g -O0",  optFlags: "-g -O", id: -gcc },
             { cc: clang, cxx: clang++, debugFlags: "-g -O0",  optFlags: "-g -O3",  id: -clang } ]

--- a/.github/workflows/petsc-docker-pr.yml
+++ b/.github/workflows/petsc-docker-pr.yml
@@ -32,7 +32,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        arch: [ { runson: ARM64, id: -arm64}, { runson: ubuntu-latest, id: -amd64 } ]
+        arch: [ { runson: ubuntu-latest, id: -amd64 } ]
+        #arch: [ { runson: ARM64, id: -arm64}, { runson: ubuntu-latest, id: -amd64 } ] # disabling arm64 until we can figure out either new machines to run these on or wipe/ reset Matt's old ones -klb
         compiler: [ 
             { cc: gcc, cxx: g++, debugFlags: "-g -O0",  optFlags: "-g -O", id: -gcc },
             { cc: clang, cxx: clang++, debugFlags: "-g -O0",  optFlags: "-g -O3",  id: -clang } ]


### PR DESCRIPTION
The github runner machines for arm 64 went down and we are disabling these tests for now since we don't the passwords for the machines/ are unaware of which machines they were on.